### PR TITLE
u-boot: Create directory for U-Boot config file

### DIFF
--- a/meta-secure-boot/recipes-secure-boot/u-boot/u-boot-imx%.bbappend
+++ b/meta-secure-boot/recipes-secure-boot/u-boot/u-boot-imx%.bbappend
@@ -23,6 +23,7 @@ do_compile:prepend:ahab() {
 BOOT_TOOLS = "imx-boot-tools"
 
 do_deploy:append:hab4() {
+    install -d ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}
     unset i j
     for type in ${UBOOT_CONFIG}; do
         i=$(expr $i + 1)


### PR DESCRIPTION
The directory may not be created when the config is being copied there.

Jira-Id: WAN-1068